### PR TITLE
Update JXDialog.java

### DIFF
--- a/swingx-core/src/main/java/org/jdesktop/swingx/JXDialog.java
+++ b/swingx-core/src/main/java/org/jdesktop/swingx/JXDialog.java
@@ -124,7 +124,7 @@ public class JXDialog extends JDialog {
      */
     public JXDialog(Window window, JComponent content) {
         super(window);
-        setContentPane(content);
+        setContent(content);
     }
 
     /**


### PR DESCRIPTION
it seems like a auto complete type there 
this constructor should call the setContent() as does any other c-tor of this class  especially that calling  setContentPane(content); does not make any sense as content may not be container and there is no other way for a user of the class to call the  setContent(content)

use case that causes an exception:

JPanel p1 = new JPanel();
Window windowAncestor = SwingUtilities.getWindowAncestor(this); String title = "tittle";
p1.setName(title);
JXDialog jf = new JXDialog(windowAncestor, p1);
jf.pack();
jf.setVisible(true); // <- content is null - exception